### PR TITLE
starting base64

### DIFF
--- a/src/cli/base64.rs
+++ b/src/cli/base64.rs
@@ -1,0 +1,22 @@
+use super::verify_input_file;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub enum Base64SubCommand {
+    #[command(name = "encode", about = "Encode a string to base64")]
+    Encode(Base64EncodeOpts),
+    #[command(name = "decode", about = "Decode a base64 string")]
+    Decode(Base64DecodeOpts),
+}
+
+#[derive(Debug, Parser)]
+pub struct Base64EncodeOpts {
+    #[arg(short, long, value_parser = verify_input_file, default_value = "-")]
+    pub input: String,
+}
+
+#[derive(Debug, Parser)]
+pub struct Base64DecodeOpts {
+    #[arg(short, long, value_parser = verify_input_file, default_value = "-")]
+    pub input: String,
+}

--- a/src/cli/csv.rs
+++ b/src/cli/csv.rs
@@ -1,20 +1,6 @@
+use super::verify_input_file;
 use clap::Parser;
-use std::{fmt, path::Path, str::FromStr};
-
-#[derive(Debug, Parser)]
-#[command(name = "rcli", version, author, about, long_about = None)]
-pub struct Opts {
-    #[command(subcommand)]
-    pub cmd: SubCommand,
-}
-
-#[derive(Debug, Parser)]
-pub enum SubCommand {
-    #[command(name = "csv", about = "Show CSV or Convert CSV to other formats")]
-    Csv(CsvOpts),
-    #[command(name = "genpass", about = "Generate a random password")]
-    GenPass(GenPassOpts),
-}
+use std::{fmt, str::FromStr};
 
 #[derive(Debug, Clone, Copy)]
 pub enum OutputFormat {
@@ -38,32 +24,6 @@ pub struct CsvOpts {
 
     #[arg(long, default_value_t = true)]
     pub header: bool,
-}
-
-#[derive(Debug, Parser)]
-pub struct GenPassOpts {
-    #[arg(short, long, default_value_t = 16)]
-    pub length: u8,
-
-    #[arg(long, default_value_t = true)]
-    pub uppercase: bool,
-
-    #[arg(long, default_value_t = true)]
-    pub lowercase: bool,
-
-    #[arg(short, long, default_value_t = true)]
-    pub number: bool,
-
-    #[arg(short, long, default_value_t = true)]
-    pub symbol: bool,
-}
-
-fn verify_input_file(filename: &str) -> Result<String, &'static str> {
-    if Path::new(filename).exists() {
-        Ok(filename.into())
-    } else {
-        Err("File does not exist")
-    }
 }
 
 fn parse_format(format: &str) -> Result<OutputFormat, anyhow::Error> {

--- a/src/cli/genpass.rs
+++ b/src/cli/genpass.rs
@@ -1,0 +1,19 @@
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub struct GenPassOpts {
+    #[arg(short, long, default_value_t = 16)]
+    pub length: u8,
+
+    #[arg(long, default_value_t = true)]
+    pub uppercase: bool,
+
+    #[arg(long, default_value_t = true)]
+    pub lowercase: bool,
+
+    #[arg(short, long, default_value_t = true)]
+    pub number: bool,
+
+    #[arg(short, long, default_value_t = true)]
+    pub symbol: bool,
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,35 @@
+pub mod base64;
+pub mod csv;
+pub mod genpass;
+
+pub use self::base64::Base64SubCommand;
+pub use self::csv::CsvOpts;
+pub use self::genpass::GenPassOpts;
+pub use clap::Parser;
+use std::path::Path;
+
+#[derive(Debug, Parser)]
+#[command(name = "rcli", version, author, about, long_about = None)]
+pub struct Opts {
+    #[command(subcommand)]
+    pub cmd: SubCommand,
+}
+
+#[derive(Debug, Parser)]
+pub enum SubCommand {
+    #[command(name = "csv", about = "Show CSV or Convert CSV to other formats")]
+    Csv(CsvOpts),
+    #[command(name = "genpass", about = "Generate a random password")]
+    GenPass(GenPassOpts),
+    #[command(subcommand, about = "Encode or decode base64")]
+    Base64(Base64SubCommand),
+}
+
+pub fn verify_input_file(filename: &str) -> Result<String, &'static str> {
+    // if input is "-" or file exists
+    if filename == "-" || Path::new(filename).exists() {
+        Ok(filename.into())
+    } else {
+        Err("File does not exist")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-mod opts;
-mod process;
+pub mod cli;
+pub mod process;
 
-pub use opts::{Opts, SubCommand};
+pub use cli::{Base64SubCommand, Opts, SubCommand};
 pub use process::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use rcli::cli::base64::*;
 use rcli::{process_csv, process_genpass, Opts, SubCommand};
 
 fn main() -> anyhow::Result<()> {
@@ -25,6 +26,14 @@ fn main() -> anyhow::Result<()> {
                 opts.symbol,
             )?;
         }
+        SubCommand::Base64(subcmd) => match subcmd {
+            Base64SubCommand::Encode(opts) => {
+                println!("{:?}", opts);
+            }
+            Base64SubCommand::Decode(opts) => {
+                println!("{:?}", opts);
+            }
+        },
     }
 
     Ok(())

--- a/src/process/csv_convert.rs
+++ b/src/process/csv_convert.rs
@@ -3,7 +3,7 @@ use csv::Reader;
 use serde::{Deserialize, Serialize};
 use std::fs;
 
-use crate::opts::OutputFormat;
+use crate::cli::csv::OutputFormat;
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]


### PR DESCRIPTION
This pull request refactors the CLI module structure and introduces new subcommands for base64 encoding and decoding. The changes include splitting the CLI options into separate modules, renaming files, and updating references throughout the codebase.

### Refactoring CLI Module Structure:

* [`src/cli/mod.rs`](diffhunk://#diff-82453e80e064c58b8fe1569389172f4a10adc0e685de6c3a787e07bcd9d98cffR1-R35): Introduced a new module to organize CLI subcommands (`base64`, `csv`, `genpass`) and restructured the main `Opts` and `SubCommand` definitions.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L1-R4): Updated to use the new `cli` module and its subcommands.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR29-R36): Updated to handle the new `Base64SubCommand` for encoding and decoding base64 strings.

### Introducing Base64 Subcommands:

* [`src/cli/base64.rs`](diffhunk://#diff-b961be249d3f243b8f7e03b7ca1dfc3676f9033c2523170689afc55b21234308R1-R22): Added new subcommands for base64 encoding and decoding, including their respective options structs (`Base64EncodeOpts` and `Base64DecodeOpts`).
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR29-R36): Integrated the new base64 subcommands into the main application logic.

### File Renaming and Updates:

* [`src/cli/csv.rs`](diffhunk://#diff-19192d990bfcd619d5789ec1c38fd7f733cb66ff62dac596e6ec583dd8d6b3edR1-R3): Renamed from `src/opts.rs` and updated to reflect the new module structure.
* [`src/cli/genpass.rs`](diffhunk://#diff-5329ad93c226061803ec6568cf5cf4ac8797a1fb484d9fd9fc665bf55f26ef14R1-R19): Moved the `GenPassOpts` struct to a new file to align with the new module structure.
* [`src/process/csv_convert.rs`](diffhunk://#diff-46c387a616993354a0f5f20dd8e0a994e14961c286d22e57af14d3a1f13258bcL6-R6): Updated import paths to use the new `cli` module structure.