### PR TITLE
starting crypto function added

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,11 +1,13 @@
 pub mod base64;
 pub mod csv;
 pub mod genpass;
+pub mod text;
 
 pub use self::base64::{Base64Format, Base64SubCommand};
 pub use self::csv::CsvOpts;
 pub use self::csv::OutputFormat;
 pub use self::genpass::GenPassOpts;
+pub use self::text::*;
 pub use clap::Parser;
 use std::path::Path;
 

--- a/src/cli/text.rs
+++ b/src/cli/text.rs
@@ -1,0 +1,27 @@
+use super::verify_input_file;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub enum TextSubCommand {
+    //如果不提供name的话，默认会将结构体名字转换为小写
+    #[command(about = "Sign a text with a private/shared key")]
+    Sign(TextSignOpts),
+    #[command(about = "Verify a signed text with a public/shared key")]
+    Verity(TextVerifyOpts),
+}
+
+#[derive(Debug, Parser)]
+pub struct TextSignOpts {
+    #[arg(short, long, value_parser = verify_input_file, default_value = "-")]
+    pub input: String,
+    #[arg(short, long, value_parser = verify_input_file, default_value = "-")]
+    pub key: String,
+}
+
+#[derive(Debug, Parser)]
+pub struct TextVerifyOpts {
+    #[arg(short, long, value_parser = verify_input_file, default_value = "-")]
+    pub input: String,
+    #[arg(short, long, value_parser = verify_input_file, default_value = "-")]
+    pub key: String,
+}


### PR DESCRIPTION
This pull request introduces a new `text` module to the CLI application, adding support for signing and verifying text with keys. The most important changes include the addition of the `text` module and its integration into the main CLI module.

### Integration of the `text` module:

* [`src/cli/mod.rs`](diffhunk://#diff-82453e80e064c58b8fe1569389172f4a10adc0e685de6c3a787e07bcd9d98cffR4-R10): Added the `text` module and re-exported its components to make them accessible from the main CLI module.

### Implementation of the `text` module:

* [`src/cli/text.rs`](diffhunk://#diff-7c17585f2206c3c69721a5d303100e6b8bdf6b2eff974539f61a696b07152ab0R1-R27): Added a new `TextSubCommand` enum with `Sign` and `Verify` variants, along with their respective option structs, `TextSignOpts` and `TextVerifyOpts`, which include arguments for the input file and key.